### PR TITLE
Update pip_packages.list

### DIFF
--- a/pip_packages.list
+++ b/pip_packages.list
@@ -29,8 +29,6 @@ requests-oauthlib==1.1.0
 requests==2.5.0
 six==1.14.0
 snowballstemmer==2.0.0
-Sphinx==1.7.5
-sphinx-theme==1.0
 sphinxcontrib-httpdomain==1.7.0
 sphinxcontrib-websupport==1.1.2
 typing==3.7.4.1


### PR DESCRIPTION
Update pip packages list

Fixes: CentralService and DataService cannot start due to import errors in modules