### PR TITLE
Firebase notification integration

### DIFF
--- a/benchmarking-tools/functional-testing-tool/tests/config.json
+++ b/benchmarking-tools/functional-testing-tool/tests/config.json
@@ -1,8 +1,0 @@
-{
-  "centralServiceUri": "http://localhost:81",
-  "dataServiceUri": "http://localhost:82",
-  "clientID": "",
-  "clientSecret": "",
-  "email": "admin@buildingdepot.org",
-  "password": ""
-}

--- a/buildingdepot/CentralService/app/rest_api/permissions/permission_request.py
+++ b/buildingdepot/CentralService/app/rest_api/permissions/permission_request.py
@@ -135,7 +135,7 @@ class PermissionRequestService(MethodView):
             sensors = self.get_sensor_objects_from_uuids(user_sensor_map[user])
             print str(user)
             permission_request_data = { "requester_name": str(requester.first_name) + " " + str(requester.last_name), "requester_email": str(get_email()), "requested_sensors": sensors }
-            PermissionRequest(email=get_email(), timestamp=str(timestamp), requests=permission_request_data).save()
+            PermissionRequest(email=user, timestamp=str(timestamp), requests=permission_request_data).save()
 
             try:
                 for user_db in User._get_collection().find({"email": user}):


### PR DESCRIPTION
Tested the system switching between RabbitMQ and Firebase Cloud Messaging, and they seem to work. The install script also adds the appropriate variables/values when selecting Firebase as the notification system. In my test, I did notice the following which I found a little strange:

![image](https://user-images.githubusercontent.com/4589562/94710155-82958b80-0314-11eb-91dc-825b5d1afd38.png)

Is the "unable to parse authentication credentials" thing an issue? I did look into it, and apparently it comes from InfluxDB.

** One last thing to add is the specific version of Firebase Admin SDK to the virtual environment, but not sure where to do that in a script.