### PR TITLE
Pull claimed mites

### DIFF
--- a/buildingdepot/CentralService/app/rest_api/sensors/sensor.py
+++ b/buildingdepot/CentralService/app/rest_api/sensors/sensor.py
@@ -170,7 +170,8 @@ class SensorOwnedService(MethodView):
         """
         email = get_email()
 
-        owned_sensors = Sensor._get_collection().find({'owner':email})
+        owned_or_claimed_query = {'$or':[{'owner':email}, {'claimed':email}]}
+        owned_sensors = Sensor._get_collection().find(owned_or_claimed_query)
         user_groups = UserGroup._get_collection().find({'users':[email]})
 
         owned = []


### PR DESCRIPTION
Doing a GET request on /api/sensor should also return any sensors the requesting user has claimed, in addition to any they have permission to or actually own.

This was something Yuvraj had wanted, and allows users to pull previously claimed Mites after the app was uninstalled.