### PR TITLE
Add timezone awareness to timeseries api

### DIFF
--- a/benchmarking-tools/functional-testing-tool/tests/all.js
+++ b/benchmarking-tools/functional-testing-tool/tests/all.js
@@ -874,6 +874,19 @@ describe('An authorized superuser should be able to ', function () {
             })
     })
 
+    it('read time-series data with timezone-aware strings', function (done) {
+        var startTime = new Date((new Date().getTime()) - (60 * 60 * 1000)).toISOString().replace('Z', '-05:00')
+        var endTime = new Date().toISOString().replace('Z', '-05:00')
+        dataApi.get('/api/sensor/' + data.get('sensor_uuid') + '/timeseries?start_time=' + encodeURIComponent(startTime) + '&end_time=' + encodeURIComponent(endTime))
+            .set('Authorization', 'Bearer ' + data.get('authorizedToken'))
+            .end(function (err, res) {
+                expect(res.status).to.equal(200)
+                expect(res.body).to.have.property('success')
+                expect(res.body.success, res.body.error).to.equal('True')
+                done()
+            })
+    })
+
     it('unsubscribe to a view', function (done) {
         dataApi.delete('/api/apps/subscription')
             .set('Authorization', 'Bearer ' + data.get('authorizedToken'))

--- a/benchmarking-tools/functional-testing-tool/tests/all.js
+++ b/benchmarking-tools/functional-testing-tool/tests/all.js
@@ -875,8 +875,9 @@ describe('An authorized superuser should be able to ', function () {
     })
 
     it('read time-series data with timezone-aware strings', function (done) {
-        var startTime = new Date((new Date().getTime()) - (60 * 60 * 1000)).toISOString().replace('Z', '-05:00')
-        var endTime = new Date().toISOString().replace('Z', '-05:00')
+        var timezoneOffset = '+00:00'
+        var startTime = new Date((new Date().getTime()) - (60 * 60 * 1000)).toISOString().replace('Z', timezoneOffset)
+        var endTime = new Date().toISOString().replace('Z', timezoneOffset)
         dataApi.get('/api/sensor/' + data.get('sensor_uuid') + '/timeseries?start_time=' + encodeURIComponent(startTime) + '&end_time=' + encodeURIComponent(endTime))
             .set('Authorization', 'Bearer ' + data.get('authorizedToken'))
             .end(function (err, res) {

--- a/buildingdepot/DataService/app/rest_api/time_utils.py
+++ b/buildingdepot/DataService/app/rest_api/time_utils.py
@@ -1,0 +1,95 @@
+"""
+DataService.rest_api.time_utils
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Shared helper functions for parsing and timezone-converting time values used
+across time-series APIs.
+"""
+
+from datetime import datetime, timezone
+
+
+def parse_time_input(time_str):
+    """Parse a time input as either a Unix timestamp or ISO 8601 string.
+
+    Args:
+        time_str: Either a Unix timestamp (int/float/string) or ISO 8601 string
+
+    Returns:
+        tuple: (unix_timestamp: float, error_message: str or None)
+               On success, returns (timestamp, None)
+               On failure, returns (None, error_message)
+    """
+    if time_str is None:
+        return (None, "Time value is required")
+
+    # First, try to parse as a Unix timestamp (int or float)
+    try:
+        timestamp = float(time_str)
+        return (timestamp, None)
+    except (ValueError, TypeError):
+        pass
+
+    # If not a valid Unix timestamp, try ISO 8601
+    time_str = str(time_str).strip()
+
+    try:
+        dt = datetime.fromisoformat(time_str)
+        return (dt.timestamp(), None)
+    except ValueError as e:
+        return (
+            None,
+            f"Invalid time format: '{time_str}'. Expected Unix timestamp or ISO 8601 format. Error: {str(e)}",
+        )
+
+
+def get_request_timezone(time_str):
+    """Extract timezone info from a time input string.
+
+    Returns the timezone if the input is an ISO 8601 string with timezone info,
+    otherwise returns None (indicating UTC).
+    """
+    if time_str is None:
+        return None
+
+    # If it's a unix timestamp (numeric), no timezone info
+    try:
+        float(time_str)
+        return None
+    except (ValueError, TypeError):
+        pass
+
+    # Try parsing as ISO 8601
+    try:
+        dt = datetime.fromisoformat(str(time_str).strip())
+        return dt.tzinfo
+    except ValueError:
+        return None
+
+
+def convert_times_to_timezone(time_values, target_tz):
+    """Convert a list of UTC time strings (from InfluxDB) to the target timezone.
+
+    Args:
+        time_values: list of ISO 8601 time strings from InfluxDB (UTC)
+        target_tz: target timezone (datetime.tzinfo), or None for no conversion
+
+    Returns:
+        list of ISO 8601 strings in target timezone
+    """
+    if target_tz is None:
+        return time_values
+
+    converted = []
+    for time_val in time_values:
+        try:
+            # Replace 'Z' with '+00:00' for fromisoformat() compatibility (Python < 3.11)
+            dt = datetime.fromisoformat(str(time_val).replace("Z", "+00:00"))
+            # If no timezone info, assume UTC
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            dt_local = dt.astimezone(target_tz)
+            converted.append(dt_local.isoformat())
+        except (ValueError, AttributeError, TypeError):
+            converted.append(time_val)
+    return converted

--- a/buildingdepot/DataService/app/rest_api/timeseries.py
+++ b/buildingdepot/DataService/app/rest_api/timeseries.py
@@ -19,6 +19,11 @@ from flask.views import MethodView
 from . import responses
 from .helper import connect_broker
 from .helper import timestamp_to_time_string, check_oauth, get_email
+from .timeseries_aggregate import (
+    parse_time_input,
+    get_request_timezone,
+    convert_times_to_timezone,
+)
 from ..models.ds_models import Sensor
 from .. import r, influx, oauth, exchange
 
@@ -62,6 +67,7 @@ class TimeSeriesService(MethodView):
         end_time = request.args.get("end_time")
         resolution = request.args.get("resolution")
         fields = request.args.get("fields")
+        response_tz = None
         original_fields = fields
         if fields:
             fields = fields.split(";")
@@ -71,6 +77,17 @@ class TimeSeriesService(MethodView):
 
         if not all([start_time, end_time]):
             return jsonify(responses.missing_parameters)
+
+        start_time_raw = start_time
+        end_time_raw = end_time
+        start_time, start_time_error = parse_time_input(start_time_raw)
+        if start_time_error:
+            return jsonify({"success": False, "error": "Invalid start_time: " + start_time_error})
+        end_time, end_time_error = parse_time_input(end_time_raw)
+        if end_time_error:
+            return jsonify({"success": False, "error": "Invalid end_time: " + end_time_error})
+
+        response_tz = get_request_timezone(start_time_raw) or get_request_timezone(end_time_raw)
 
         if r.sismember("views", name):
             allowed_fields = [
@@ -138,6 +155,11 @@ class TimeSeriesService(MethodView):
         # print ('#' * 100 + '\n\n')
         response.update({"data": data.raw})
         del response["data"]["statement_id"]
+
+        if response_tz and "series" in response["data"]:
+            for series in response["data"]["series"]:
+                if "time" in series and isinstance(series["time"], list):
+                    series["time"] = convert_times_to_timezone(series["time"], response_tz)
 
         return jsonify(response)
 

--- a/buildingdepot/DataService/app/rest_api/timeseries.py
+++ b/buildingdepot/DataService/app/rest_api/timeseries.py
@@ -67,7 +67,6 @@ class TimeSeriesService(MethodView):
         end_time = request.args.get("end_time")
         resolution = request.args.get("resolution")
         fields = request.args.get("fields")
-        response_tz = None
         original_fields = fields
         if fields:
             fields = fields.split(";")
@@ -82,10 +81,14 @@ class TimeSeriesService(MethodView):
         end_time_raw = end_time
         start_time, start_time_error = parse_time_input(start_time_raw)
         if start_time_error:
-            return jsonify({"success": False, "error": "Invalid start_time: " + start_time_error})
+            response = dict(responses.success_false)
+            response.update({"error": "Invalid start_time: " + start_time_error})
+            return jsonify(response)
         end_time, end_time_error = parse_time_input(end_time_raw)
         if end_time_error:
-            return jsonify({"success": False, "error": "Invalid end_time: " + end_time_error})
+            response = dict(responses.success_false)
+            response.update({"error": "Invalid end_time: " + end_time_error})
+            return jsonify(response)
 
         response_tz = get_request_timezone(start_time_raw) or get_request_timezone(end_time_raw)
 
@@ -158,8 +161,19 @@ class TimeSeriesService(MethodView):
 
         if response_tz and "series" in response["data"]:
             for series in response["data"]["series"]:
-                if "time" in series and isinstance(series["time"], list):
-                    series["time"] = convert_times_to_timezone(series["time"], response_tz)
+                if (
+                    "columns" in series
+                    and "values" in series
+                    and isinstance(series["columns"], list)
+                    and isinstance(series["values"], list)
+                    and "time" in series["columns"]
+                ):
+                    time_index = series["columns"].index("time")
+                    rows_with_time = [row for row in series["values"] if len(row) > time_index]
+                    time_values = [row[time_index] for row in rows_with_time]
+                    converted_times = convert_times_to_timezone(time_values, response_tz)
+                    for row, converted_time in zip(rows_with_time, converted_times):
+                        row[time_index] = converted_time
 
         return jsonify(response)
 

--- a/buildingdepot/DataService/app/rest_api/timeseries.py
+++ b/buildingdepot/DataService/app/rest_api/timeseries.py
@@ -19,7 +19,7 @@ from flask.views import MethodView
 from . import responses
 from .helper import connect_broker
 from .helper import timestamp_to_time_string, check_oauth, get_email
-from .timeseries_aggregate import (
+from .time_utils import (
     parse_time_input,
     get_request_timezone,
     convert_times_to_timezone,

--- a/buildingdepot/DataService/app/rest_api/timeseries_aggregate.py
+++ b/buildingdepot/DataService/app/rest_api/timeseries_aggregate.py
@@ -16,13 +16,14 @@ import time
 import yaml
 import os
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from collections import defaultdict, namedtuple
 from flask import request, jsonify
 from flask.views import MethodView
 
 from . import responses
 from .helper import timestamp_to_time_string, check_oauth, get_email, form_query, check_if_super
+from .time_utils import parse_time_input, get_request_timezone, convert_times_to_timezone
 from ..models.ds_models import Sensor, AggregateTimeSeriesAccessLog
 from .. import r, influx, oauth, exchange
 
@@ -44,89 +45,6 @@ def load_access_control_policies():
     policy_file = os.path.join(os.path.dirname(__file__), "access_control_policies.yaml")
     with open(policy_file, 'r') as f:
         return yaml.safe_load(f)
-
-
-def parse_time_input(time_str):
-    """Parse a time input as either a Unix timestamp or ISO 8601 string.
-    
-    Args:
-        time_str: Either a Unix timestamp (int/float/string) or ISO 8601 string
-    
-    Returns:
-        tuple: (unix_timestamp: float, error_message: str or None)
-               On success, returns (timestamp, None)
-               On failure, returns (None, error_message)
-    """
-    if time_str is None:
-        return (None, "Time value is required")
-    
-    # First, try to parse as a Unix timestamp (int or float)
-    try:
-        timestamp = float(time_str)
-        return (timestamp, None)
-    except (ValueError, TypeError):
-        pass
-    
-    # If not a valid Unix timestamp, try ISO 8601
-    time_str = str(time_str).strip()
-    
-    try:
-        dt = datetime.fromisoformat(time_str)
-        return (dt.timestamp(), None)
-    except ValueError as e:
-        return (None, f"Invalid time format: '{time_str}'. Expected Unix timestamp or ISO 8601 format. Error: {str(e)}")
-
-
-def get_request_timezone(time_str):
-    """Extract timezone info from a time input string.
-
-    Returns the timezone if the input is an ISO 8601 string with timezone info,
-    otherwise returns None (indicating UTC).
-    """
-    if time_str is None:
-        return None
-
-    # If it's a unix timestamp (numeric), no timezone info
-    try:
-        float(time_str)
-        return None
-    except (ValueError, TypeError):
-        pass
-
-    # Try parsing as ISO 8601
-    try:
-        dt = datetime.fromisoformat(str(time_str).strip())
-        return dt.tzinfo
-    except ValueError:
-        return None
-
-
-def convert_times_to_timezone(time_values, target_tz):
-    """Convert a list of UTC time strings (from InfluxDB) to the target timezone.
-
-    Args:
-        time_values: list of ISO 8601 time strings from InfluxDB (UTC)
-        target_tz: target timezone (datetime.tzinfo), or None for no conversion
-
-    Returns:
-        list of ISO 8601 strings in target timezone
-    """
-    if target_tz is None:
-        return time_values
-
-    converted = []
-    for time_val in time_values:
-        try:
-            # Replace 'Z' with '+00:00' for fromisoformat() compatibility (Python < 3.11)
-            dt = datetime.fromisoformat(str(time_val).replace('Z', '+00:00'))
-            # If no timezone info, assume UTC
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            dt_local = dt.astimezone(target_tz)
-            converted.append(dt_local.isoformat())
-        except (ValueError, AttributeError, TypeError):
-            converted.append(time_val)
-    return converted
 
 
 class AggregateTimeSeriesService(MethodView):


### PR DESCRIPTION
The aggregate timeseries API already supports timezone-aware ISO 8601 inputs; the sensor timeseries endpoint did not. This change aligns `/api/sensor/<name>/timeseries` with the same time parsing and timezone response behavior.

- **API behavior alignment**
  - Uses shared time helpers in `rest_api/time_utils.py`:
    - `parse_time_input` (unix timestamp or ISO 8601 input)
    - `get_request_timezone` (extract requested timezone)
    - `convert_times_to_timezone` (convert returned timestamps to requested timezone)
  - Added structured invalid-time responses for `start_time` / `end_time` using existing API response conventions.
  - Updated both aggregate and non-aggregate timeseries endpoints to import these helpers from the shared utility module (instead of importing from `timeseries_aggregate`).

- **Response timestamp conversion**
  - Applied timezone conversion to non-aggregate InfluxDB result shape (`series.columns` + `series.values`) by locating the `time` column and converting those values in-place.

- **Focused functional coverage**
  - Added a test case in the existing functional suite to query `/api/sensor/<uuid>/timeseries` with timezone-aware ISO 8601 query params and assert successful handling.

```python
# timeseries.py (conceptual flow)
start_time, err = parse_time_input(start_time_raw)
end_time, err = parse_time_input(end_time_raw)
response_tz = get_request_timezone(start_time_raw) or get_request_timezone(end_time_raw)

# convert `time` column in series.values to response_tz
converted_times = convert_times_to_timezone(time_values, response_tz)
```

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> 
> ----
> 
> *This section details on the original issue you should resolve*
> 
> <issue_title>/api/sensor/.../timeseries should take timezone-aware strings</issue_title>
> <issue_description>PR Mites-io/BuildingDepot-v3#21 added time zone awareness to the aggregate data timeseries api. The other timeseries API should be extended to have the same functionality.</issue_description>
> 
> ## Comments on the Issue (you are @copilot in this section)
> 
> <comments>
> </comments>
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes Mites-io/BuildingDepot-v3#22

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/Mites-io/BuildingDepot-v3/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
