### PR TITLE
docker: containerized BuildingDepot dev/deploy stack

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,38 @@
+# BuildingDepot docker compose env. Copy to docker/.env and edit.
+#
+# Generate fresh secrets with:
+#   for v in MONGO_PWD INFLUX_PWD REDIS_PWD RABBIT_ADMIN_PWD RABBIT_END_PWD SECRET_KEY ; do
+#     printf '%s=%s\n' "$v" "$(openssl rand -hex 32)"
+#   done
+
+# --- Flask ---
+SECRET_KEY=replace-me-with-openssl-rand-hex-32
+
+# --- Mongo ---
+MONGO_USER=bdadmin
+MONGO_PWD=replace-me
+
+# --- Influx 1.x ---
+INFLUX_USER=bdadmin
+INFLUX_PWD=replace-me
+INFLUX_DB=buildingdepot
+
+# --- Redis ---
+REDIS_PWD=replace-me
+
+# --- RabbitMQ ---
+# Read at DataService import time even if you don't publish.
+RABBIT_ADMIN_USER=bdadmin
+RABBIT_ADMIN_PWD=replace-me
+RABBIT_END_USER=bduser
+RABBIT_END_PWD=replace-me
+
+# --- Public ports (host-side) ---
+# Match legacy: CentralService 81, DataService 82.
+HOST_PORT_CS=81
+HOST_PORT_DS=82
+
+# --- SMTP (dev) ---
+# Point CentralService at the mailpit catcher. Defaults to localhost:25 if unset.
+SMTP_HOST=mailpit
+SMTP_PORT=1025

--- a/docker/Dockerfile.bd
+++ b/docker/Dockerfile.bd
@@ -1,0 +1,27 @@
+# BD app image: replica + central + data all run from this image,
+# differentiated by `command:` in compose.
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/opt/venv \
+    PATH=/opt/venv/bin:/root/.local/bin:$PATH \
+    BD_SETTINGS=/etc/buildingdepot/bd_settings.cfg
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl ca-certificates build-essential \
+ && rm -rf /var/lib/apt/lists/* \
+ && curl -LsSf https://astral.sh/uv/install.sh | sh
+
+WORKDIR /app
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project
+
+COPY buildingdepot ./buildingdepot
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+ && mkdir -p /etc/buildingdepot /var/log/buildingdepot
+
+WORKDIR /app/buildingdepot
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/IMPLEMENTATION.md
+++ b/docker/IMPLEMENTATION.md
@@ -1,0 +1,118 @@
+# BuildingDepot on Docker: how this stack is built and why
+
+This is the guide for someone who has never touched BuildingDepot and now has to run it, understand it, or change it. It explains what BuildingDepot is, what each container does, why the setup is split the way it is, and how to bring it all up from nothing. Read it top to bottom once and the compose file will stop looking mysterious.
+
+## What BuildingDepot is
+
+BuildingDepot (BD) is a store for building sensor data. It keeps two very different kinds of data and keeps them separate on purpose. The first is the data model: buildings, the sensors in them, the tags that describe those sensors, the users who can see them, and the access rules. The second is the actual timeseries: the stream of readings each sensor produces over time. BD is the sink: an upstream backend writes sensor samples into BD, which is where downstream services such as dashboards and analytics later read them from.
+
+BD is an old codebase. It was written to run as a few Python processes sitting on one machine next to their databases, talking to each other over localhost. This compose stack takes that same code and runs each piece in its own container, which is cleaner and reproducible, but it means a few places where the code assumed localhost have to be nudged to point at the right container instead. Those nudges are called out below so they do not surprise you.
+
+## The shape of the stack
+
+There are nine containers. Four are off-the-shelf data stores, three are BuildingDepot's own processes, one is nginx in front, and one is a dev mail catcher. They split into three groups.
+
+The backing stores hold state:
+
+- **mongo** is the metadata database. Users, buildings, sensors, tags, OAuth clients, and the registry of data services all live here. This is BD's source of truth for everything except the raw timeseries.
+- **influxdb** is the timeseries database, where the sensor readings themselves go. It is pinned to the 1.8 line because BD's Python client speaks the InfluxDB v1 protocol. Do not bump it to 2.x without porting that client.
+- **redis** holds short-lived state: OAuth access tokens, and the temporary passwords from the reset flow that expire after fifteen minutes.
+- **rabbitmq** is the live fan-out. When sensor data lands, BD publishes it to a RabbitMQ exchange, and anything that wants the live stream subscribes. Native clients use AMQP, and browsers use web-STOMP over a websocket. This is the only data store whose ports are published to the host, because those live consumers run outside the compose network.
+
+The three BuildingDepot processes are where BD's own logic runs:
+
+- **bd-replica** is the CentralReplica. It is a small XML-RPC server on port 8080 that the other two processes call for shared central operations. Think of it as the inner authority the API layer leans on.
+- **bd-central** is the CentralService, usually shortened to CS. This is the main REST API. Login and OAuth, creating users, defining buildings and sensors, tags, permissions: all of it is CS. It runs under gunicorn on 8081.
+- **bd-data** is the DataService, shortened to DS. This is the timeseries side. Posting readings and querying them back out of InfluxDB goes through DS. It runs under gunicorn on 8082, with a longer request timeout because timeseries queries can be heavy.
+
+In front of everything sits **nginx**, the single entry point. It listens on 81 and forwards to CS, and on 82 and forwards to DS. Clients only ever talk to 81 and 82, never to the gunicorn ports directly. nginx is also where TLS is terminated.
+
+Last is **mailpit**, which only exists in dev. CentralService emails a temporary password on signup and password reset, and with no real mail server around, mailpit catches those messages so you can read them in a browser. It is described in the README, not here.
+
+## One image, three different processes
+
+All three BD processes are the same code, so they are the same image. `Dockerfile.bd` builds one `buildingdepot:dev` image: a slim Python 3.12 base, dependencies installed with uv from the locked pyproject, then the `buildingdepot` source copied in. The image does not pick a process to run. That choice is made in compose.
+
+The compose file uses a YAML anchor called `x-bd-app` to avoid repeating itself. The anchor carries the build instructions, the env file, the restart policy, and the dependency on the four data stores. Each of the three BD services pulls in that anchor and then sets its own `command:`. The replica runs `python3 main.py`, central runs gunicorn against `CentralService:app`, and data runs gunicorn against `DataService:app`. Same image, three jobs, decided by the command line.
+
+## How configuration and secrets work
+
+BD reads its settings from a file, not from environment variables directly. CS and DS load a Flask config file whose path is given by the `BD_SETTINGS` environment variable, and CentralReplica imports a plain `config.py` module. Rather than baking either file into the image, the image's entrypoint writes both of them at container start from environment values. That keeps every secret out of the built image and lets the same image run against different credentials.
+
+So the flow on each container boot is: `entrypoint.sh` reads the environment, checks the required secrets are present, renders `bd_settings.cfg` and `CentralReplica/config.py`, and then execs the service command. The environment values themselves come from `docker/.env`, which compose loads through the anchor. This is why `.env` is the one file you must fill in before anything works, and why it is git-ignored.
+
+The entrypoint does one more thing worth knowing. The legacy CS and DS code hardcodes the CentralReplica's address as localhost, because originally the replica ran on the same machine. In this stack the replica is its own container named bd-replica, so the entrypoint runs two small sed patches that rewrite those localhost XML-RPC URLs to `bd-replica:8080`. Without that the API processes could not reach the replica.
+
+## How the pieces find each other
+
+Containers on the same compose network reach each other by service name. CS and DS connect to `mongo`, `redis`, `influxdb`, and `rabbitmq` by those names, which is exactly what the rendered settings contain. nginx forwards to `bd-central` and `bd-data` by name. The replica is reached at `bd-replica`.
+
+There is one registration detail that lives in the database rather than in config. BD keeps a registry of data services in Mongo, and CS looks a data service up there to find the host it should call for certain operations. The bootstrap step writes a row named `ds1` with its host set to `bd-replica`, so that CS's lookups resolve to the replica container. That row is easy to miss and the system does not work without it, which is why bootstrap creates it for you.
+
+## Bringing it up from zero
+
+You need Docker with the compose plugin. Everything below runs from this `docker/` directory.
+
+First, create your environment file and fill in secrets:
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and replace every `replace-me`. The header of the file has a one-liner that generates strong values with openssl. These are the Mongo, Influx, Redis, and RabbitMQ credentials plus the Flask secret key. The same values get rendered into the BD settings at boot, so the apps and the stores agree.
+
+Then build the image and start the whole stack:
+
+```bash
+docker compose up -d --build
+```
+
+Compose builds `buildingdepot:dev` once, starts the four data stores, waits for each to report healthy, then starts the replica, then CS and DS once the replica is healthy, then nginx. The health gating is why startup is ordered and not a race.
+
+Now create the admin user and register the data service:
+
+```bash
+./bootstrap_admin.sh
+```
+
+This runs a short script inside the bd-central container. It inserts the super user `admin@buildingdepot.org` into Mongo with a random temporary password that it prints once, and it upserts the `ds1` data service row pointing at bd-replica. Running it again is safe. If the admin already exists, Mongo rejects the duplicate and the script moves on.
+
+At this point BD is up with an empty data model. Populate it (tag types, buildings, sensors, users) by calling CS's REST API with admin OAuth client credentials.
+
+To check the stack is serving:
+
+```bash
+curl -s -o /dev/null -w "CS %{http_code}\n" http://localhost:81/auth/login
+curl -s -o /dev/null -w "DS %{http_code}\n" http://localhost:82/
+```
+
+## Ports and who talks to them
+
+| Host port | Lands on | Used by |
+|---|---|---|
+| 81 | nginx to CentralService | REST API: login, users, buildings, sensors, tags |
+| 82 | nginx to DataService | timeseries reads and writes |
+| 5672 | RabbitMQ AMQP | native live consumers |
+| 15672 | RabbitMQ management | the broker's admin UI and HTTP API |
+| 15674 | RabbitMQ web-STOMP | browser live streaming over websocket |
+| 8025 | mailpit | reading dev signup and reset emails |
+
+The gunicorn ports 8081 and 8082, the replica's 8080, and the four data stores' own ports stay inside the compose network. Nothing outside reaches them directly.
+
+## Day to day
+
+Logs come from compose. `docker compose logs -f bd-central` follows CentralService, and the same works for any service name. The CS access log is noisy because the health check hits `/auth/login` every few seconds, so filter that out when you are hunting for real errors.
+
+After a code change, rebuild and restart with `docker compose up -d --build`. Compose rebuilds the shared image and recreates the BD services that use it.
+
+There is one sharp edge worth remembering. nginx resolves `bd-central` and `bd-data` to their container IPs once, when it starts. If you recreate either of those containers on its own, it can come back with a new IP while nginx still points at the old one, and you get a 502 until nginx is restarted. So after recreating a BD app container, restart nginx with `docker compose restart nginx`.
+
+Email and TLS each have their own section in the README. The short version is that mailpit catches dev mail on 8025, and nginx terminates TLS on 81 and 82 using a cert that `refresh-cert.sh` issues from either Let's Encrypt or Tailscale. The README walks through both.
+
+## State and resetting
+
+The four data stores keep their data in named volumes: `mongo-data`, `redis-data`, `influx-data`, and `rabbit-data`. They survive `docker compose down` and a normal restart. To wipe everything and start from a truly blank slate, `docker compose down -v` removes the volumes too, after which you start over from the env file and bootstrap.
+
+## Why it is shaped this way
+
+The design choices all come back to a few ideas. Keep the metadata and the timeseries in the databases each is good at, which is Mongo and InfluxDB. Run BD's three processes as separate containers so each can be scaled, restarted, and read in logs on its own, while still sharing one image so there is only one thing to build. Render config and secrets at container start so the image stays clean and portable. Put a single nginx in front so there is one address surface and one place for TLS. Expose RabbitMQ to the host because the live consumers genuinely live outside this stack. Everything else, the health gating, the bootstrap, the XML-RPC patching, exists to make an older single-host codebase behave correctly now that its parts live in separate containers.

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,14 +8,16 @@ Dev/test stack. Brings up Mongo + Redis + InfluxDB 1.8 + RabbitMQ + the three BD
 cd docker
 cp .env.example .env
 # edit .env — at minimum replace every `replace-me`
+# provision TLS certs into docker/certs (required for nginx + RabbitMQ wss); see "TLS" below
+sudo CERT_PROVIDER=tailscale ./refresh-cert.sh   # or CERT_PROVIDER=certbot BD_CERT_DOMAIN=...
 docker compose up -d --build
 ./bootstrap_admin.sh         # creates admin@buildingdepot.org + registers ds1
 ```
 
 Then:
 
-- CentralService — `http://localhost:81`
-- DataService — `http://localhost:82`
+- CentralService — `https://localhost:81`
+- DataService — `https://localhost:82`
 - Mailpit inbox — `http://localhost:8025`
 
 ## Email (dev SMTP)
@@ -75,7 +77,7 @@ Reach BD at `https://<node>.<tailnet>.ts.net:81` / `:82`. Certs are 90-day; run 
 
 ### Live data over wss (RabbitMQ web-STOMP)
 
-Browsers stream live sensor data over web-STOMP, and an `https://` page can only open a `wss://` socket. RabbitMQ serves that on **15675** using the same `certs/bd.crt` / `bd.key`, configured in `rabbitmq.conf`. Plain `ws://` stays on 15674 for in-network use. nginx runs as root so it reads the `0600` key, but the RabbitMQ node runs as the unprivileged `rabbitmq` user, so `refresh-cert.sh` sets the key world-readable (`0644`) after issuing it. That is fine on a single-user host; the key never leaves the box. Point the UI at `wss://<node>.<tailnet>.ts.net:15675/ws` (`PUBLIC_RABBITMQ_HOSTNAME` = the node name, `PUBLIC_RABBITMQ_PORT` = 15675).
+Browsers stream live sensor data over web-STOMP, and an `https://` page can only open a `wss://` socket. RabbitMQ serves that on **15675** using the same `certs/bd.crt` / `bd.key`, configured in `rabbitmq.conf`. Plain `ws://` stays on 15674 for in-network use. nginx runs as root so it can read the private key, but the RabbitMQ node runs as the unprivileged `rabbitmq` user, so `refresh-cert.sh` makes the key group-readable (`0640`) and sets its group to RabbitMQ’s container GID (default `999`, override via `RABBITMQ_CERT_GID`). Point the UI at `wss://<node>.<tailnet>.ts.net:15675/ws` (`PUBLIC_RABBITMQ_HOSTNAME` = the node name, `PUBLIC_RABBITMQ_PORT` = 15675).
 
 ## RabbitMQ access (BD token as the broker credential)
 
@@ -104,5 +106,5 @@ Design and rationale: `docs/rabbitmq-auth.md`.
 
 - **InfluxDB 1.8** — BD pins `influxdb-python==5.3.1` which speaks the v1 line protocol. Do not bump to 2.x without porting the BD client.
 - **Secrets at container start, not build time.** `entrypoint.sh` renders `bd_settings.cfg` and `CentralReplica/config.py` from env. The image has no secrets baked in.
-- **No TLS in this compose.** Add a real cert at the nginx layer for production.
+- **TLS is terminated at nginx (81/82).** Provision `certs/bd.crt` + `certs/bd.key` (via `refresh-cert.sh`) before relying on HTTPS/wss.
 - **Volumes** are named (`mongo-data`, `redis-data`, `influx-data`, `rabbit-data`). Survive `docker compose down`; wiped by `docker compose down -v`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,108 @@
+# BuildingDepot — Docker Compose
+
+Dev/test stack. Brings up Mongo + Redis + InfluxDB 1.8 + RabbitMQ + the three BD app processes (CentralReplica XML-RPC, CentralService gunicorn, DataService gunicorn) behind nginx.
+
+## Quick start
+
+```bash
+cd docker
+cp .env.example .env
+# edit .env — at minimum replace every `replace-me`
+docker compose up -d --build
+./bootstrap_admin.sh         # creates admin@buildingdepot.org + registers ds1
+```
+
+Then:
+
+- CentralService — `http://localhost:81`
+- DataService — `http://localhost:82`
+- Mailpit inbox — `http://localhost:8025`
+
+## Email (dev SMTP)
+
+CentralService emails a temporary password on signup and password reset. There is no real mail server in dev, so a [Mailpit](https://mailpit.axllent.org/) container catches every message — read them at `http://localhost:8025` instead of an inbox.
+
+How it is wired:
+
+- `helper.py` sends via `SMTP_HOST:SMTP_PORT` (default `localhost:25`).
+- `.env` sets `SMTP_HOST=mailpit` / `SMTP_PORT=1025`; `entrypoint.sh` renders them into `bd_settings.cfg`.
+- The `mailpit` service listens on `1025` (SMTP) and `8025` (web inbox).
+
+To get a usable password for a user: `POST /oauth/reset {email}`, open Mailpit, copy the temp password, then `POST /oauth/confirmReset {email, temp_password, new_password}`. Leave `SMTP_HOST`/`SMTP_PORT` unset to fall back to a local mailer.
+
+## TLS (reverse proxy)
+
+nginx terminates TLS on **81 (CS)** and **82 (DS)** so clients keep using `https://<host>:81` / `:82` unchanged. nginx only reads `certs/bd.crt` + `certs/bd.key`; how those PEMs are issued is `refresh-cert.sh`'s job, and it supports two scenarios. `certs/` holds the PEMs and is git-ignored. The connecting hostname must match the cert's name in both cases.
+
+First cutover, either way, is the same once the cert exists:
+
+```bash
+cd docker
+sudo CERT_PROVIDER=... [BD_CERT_DOMAIN=...] ./refresh-cert.sh   # writes certs/bd.crt + bd.key
+docker compose up -d --force-recreate nginx                    # load the TLS config
+```
+
+### Public IP -> Let's Encrypt (certbot)
+
+For a host with a public IP and a real domain whose A record points at it. certbot gets the cert over HTTP-01 (needs port 80 free and reachable), and the script copies the PEMs into `certs/`.
+
+```bash
+sudo apt install certbot
+cd docker
+sudo BD_CERT_DOMAIN=bd.example.com CERTBOT_EMAIL=you@example.com CERT_PROVIDER=certbot ./refresh-cert.sh
+docker compose up -d --force-recreate nginx
+```
+
+Reach BD at `https://bd.example.com:81` / `:82`. Renewal is handled by certbot's own systemd timer; add a deploy hook so it recopies + reloads after each renew:
+
+```bash
+sudo certbot renew --deploy-hook "/path/to/docker/refresh-cert.sh"
+```
+
+(For a host behind NAT/CGNAT with a public domain, use a certbot DNS-01 plugin instead of `--standalone`; the copy + reload step is identical.)
+
+### Private / no public IP -> Tailscale (default)
+
+For a host with no public IP. The cert comes from Tailscale for the node's MagicDNS name (Let's Encrypt backed, validated over the `ts.net` DNS), so no public IP, owned domain, or open ports are needed. Requires `tailscale up` and HTTPS certs enabled in the tailnet admin console.
+
+```bash
+cd docker
+sudo ./refresh-cert.sh                        # CERT_PROVIDER defaults to tailscale
+docker compose up -d --force-recreate nginx
+```
+
+Reach BD at `https://<node>.<tailnet>.ts.net:81` / `:82`. Certs are 90-day; run `refresh-cert.sh` on a daily systemd timer or cron to auto-renew (it reloads nginx). WireGuard already encrypts the transport, so this TLS is mainly so browsers get a trusted `https://`.
+
+### Live data over wss (RabbitMQ web-STOMP)
+
+Browsers stream live sensor data over web-STOMP, and an `https://` page can only open a `wss://` socket. RabbitMQ serves that on **15675** using the same `certs/bd.crt` / `bd.key`, configured in `rabbitmq.conf`. Plain `ws://` stays on 15674 for in-network use. nginx runs as root so it reads the `0600` key, but the RabbitMQ node runs as the unprivileged `rabbitmq` user, so `refresh-cert.sh` sets the key world-readable (`0644`) after issuing it. That is fine on a single-user host; the key never leaves the box. Point the UI at `wss://<node>.<tailnet>.ts.net:15675/ws` (`PUBLIC_RABBITMQ_HOSTNAME` = the node name, `PUBLIC_RABBITMQ_PORT` = 15675).
+
+## RabbitMQ access (BD token as the broker credential)
+
+Clients authenticate to RabbitMQ with a **BuildingDepot OAuth token**, not a broker password. A client connects with its email as the login and its BD token as the passcode, and RabbitMQ asks CentralService whether that token may read a given sensor. So there is one token and one authority: BD owns permissions, the broker just enforces them. No shared broker password is handed to browsers.
+
+This is on by default from a fresh `docker compose up`. The two plugins (`rabbitmq_auth_backend_http`, `rabbitmq_auth_backend_cache`) ship in `rabbitmq-enabled-plugins`, and the backend chain plus the four CentralService endpoints are configured in `rabbitmq.conf`. RabbitMQ tries its internal backend first (so `bdadmin`, used for ops and the ingest publisher, is unchanged) and falls back to the HTTP backend for everyone else. Adding it is purely additive.
+
+Connecting as a user (for example over STOMP or web-STOMP):
+
+```
+login:    <user email>
+passcode: <BD OAuth access token>
+host:     /
+```
+
+Subscribe to `/exchange/master_exchange/<sensor_id>`. The subscription is allowed only if BD's ACL grants that user read on that sensor.
+
+Two setup-flow notes:
+
+- **`master_exchange` is now a `topic` exchange** (it was `direct`). Per-sensor authorization needs the topic exchange so RabbitMQ runs its per-routing-key check. A fresh deployment creates it as `topic` on the first publish, nothing to do. An existing deployment that already has a `direct` `master_exchange` must delete it once so it is recreated as `topic` (`rabbitmqctl delete exchange master_exchange`, or `docker compose down -v` in dev).
+- **Token auth needs `bd-central` reachable.** RabbitMQ calls CentralService to authorize, with a short cache. Internal users (`bdadmin`) keep working even if BD is down; token users cannot connect until BD is up. There is no compose `depends_on` from rabbitmq to bd-central (that would be a cycle), and none is needed since auth happens on client connect, by which point BD is up.
+
+Design and rationale: `docs/rabbitmq-auth.md`.
+
+## Notes
+
+- **InfluxDB 1.8** — BD pins `influxdb-python==5.3.1` which speaks the v1 line protocol. Do not bump to 2.x without porting the BD client.
+- **Secrets at container start, not build time.** `entrypoint.sh` renders `bd_settings.cfg` and `CentralReplica/config.py` from env. The image has no secrets baked in.
+- **No TLS in this compose.** Add a real cert at the nginx layer for production.
+- **Volumes** are named (`mongo-data`, `redis-data`, `influx-data`, `rabbit-data`). Survive `docker compose down`; wiped by `docker compose down -v`.

--- a/docker/bootstrap_admin.sh
+++ b/docker/bootstrap_admin.sh
@@ -45,7 +45,7 @@ except Exception as e:
 db.data_service.update_one(
     {'name': 'ds1'},
     {'$set': {
-        'name': 'ds1', 'description': '', 'host': 'bd-replica', 'port': 8082,
+        'name': 'ds1', 'description': '', 'host': 'bd-replica', 'port': '8082',
     }, '$setOnInsert': {'buildings': [], 'admins': []}},
     upsert=True,
 )

--- a/docker/bootstrap_admin.sh
+++ b/docker/bootstrap_admin.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# One-shot: create the BD admin user inside the running bd-central container.
+# Idempotent: if the user already exists, MongoDB raises DuplicateKey and we exit 0.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+if ! docker compose ps --status running bd-central | grep -q bd-central ; then
+  echo "bd-central not running — start the stack first: docker compose up -d" >&2
+  exit 1
+fi
+
+docker compose exec -T bd-central python3 - <<'PY'
+import configparser, io, os, random, string
+from pymongo import MongoClient
+from werkzeug.security import generate_password_hash
+
+cfg = configparser.ConfigParser()
+buf = io.StringIO('[s]\n' + open(os.environ['BD_SETTINGS']).read())
+cfg.read_file(buf)
+user = cfg.get('s', 'MONGODB_USERNAME').strip("'\"")
+pwd  = cfg.get('s', 'MONGODB_PWD').strip("'\"")
+
+tmp = ''.join(random.choice(string.ascii_letters + string.digits) for _ in range(16))
+client = MongoClient(host='mongo', port=27017, username=user, password=pwd, authSource='admin')
+db = client.buildingdepot
+try:
+    db.user.insert_one({
+        'email': 'admin@buildingdepot.org',
+        'password': generate_password_hash(tmp),
+        'first_name': 'Admin',
+        'first_login': True,
+        'role': 'super',
+    })
+    print(f'\nadmin@buildingdepot.org / {tmp}  (change on first login)\n')
+except Exception as e:
+    if 'duplicate key' in str(e).lower():
+        print('admin user already exists — skipping')
+    else:
+        raise
+
+# `host` is what CentralService uses to call the replica's XML-RPC on :8080
+# (see CentralService/app/rpc/defs.py:get_remote). Must point at the replica
+# container, NOT bd-data — they are separate services in the compose stack.
+db.data_service.update_one(
+    {'name': 'ds1'},
+    {'$set': {
+        'name': 'ds1', 'description': '', 'host': 'bd-replica', 'port': 8082,
+    }, '$setOnInsert': {'buildings': [], 'admins': []}},
+    upsert=True,
+)
+print("registered data service ds1 (host='bd-replica' for XML-RPC)")
+PY

--- a/docker/certs/.gitignore
+++ b/docker/certs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,179 @@
+# BuildingDepot dev/test stack. Run from this directory:
+#   cp .env.example .env && $EDITOR .env
+#   docker compose up -d --build
+#   ./bootstrap_admin.sh
+# Production deploy will fork this for TLS, real volumes, and resource limits.
+
+name: buildingdepot
+
+x-bd-app: &bd-app
+  build:
+    context: ..
+    dockerfile: docker/Dockerfile.bd
+  image: buildingdepot:dev
+  pull_policy: build  # locally built — never try to fetch from a registry
+  env_file: .env
+  restart: unless-stopped
+  depends_on:
+    mongo:     { condition: service_healthy }
+    redis:     { condition: service_healthy }
+    influxdb:  { condition: service_healthy }
+    rabbitmq:  { condition: service_healthy }
+
+services:
+  mongo:
+    image: mongo:7
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PWD}
+    volumes:
+      - mongo-data:/data/db
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping').ok"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--requirepass", "${REDIS_PWD}", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PWD}", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  influxdb:
+    # 1.x — BD pins influxdb-python==5.3.1 which speaks the v1 line protocol.
+    image: influxdb:1.8
+    restart: unless-stopped
+    environment:
+      INFLUXDB_HTTP_AUTH_ENABLED: "true"
+      INFLUXDB_ADMIN_USER: ${INFLUX_USER}
+      INFLUXDB_ADMIN_PASSWORD: ${INFLUX_PWD}
+      INFLUXDB_DB: ${INFLUX_DB}
+    volumes:
+      - influx-data:/var/lib/influxdb
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8086/ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    restart: unless-stopped
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBIT_ADMIN_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBIT_ADMIN_PWD}
+    # Broker reachable from the host so non-container clients (analytics consumers,
+    # a web UI) can consume BD's live fan-out. AMQP for native clients; web-STOMP for websockets.
+    ports:
+      - "${HOST_PORT_AMQP:-5672}:5672"            # AMQP (e.g. native pika clients)
+      - "${HOST_PORT_RABBIT_MGMT:-15672}:15672"   # management UI + HTTP API
+      - "${HOST_PORT_RABBIT_WS:-15674}:15674"     # web-STOMP plain ws (in-network)
+      - "${HOST_PORT_RABBIT_WSS:-15675}:15675"    # web-STOMP over TLS (wss: browsers)
+    volumes:
+      - rabbit-data:/var/lib/rabbitmq
+      # Enable web-STOMP (websocket) alongside management; see rabbitmq-enabled-plugins.
+      - ./rabbitmq-enabled-plugins:/etc/rabbitmq/enabled_plugins:ro
+      # TLS web-STOMP on 15675 using the Tailscale cert (see rabbitmq.conf).
+      - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
+      - ./certs:/etc/rabbitmq/certs:ro
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+
+  bd-replica:
+    <<: *bd-app
+    working_dir: /app/buildingdepot/CentralReplica
+    command: ["python3", "main.py"]
+    healthcheck:
+      # XML-RPC server returns "Method Not Allowed" on plain GET — that's
+      # enough to prove the socket is up and the process is serving.
+      test: ["CMD-SHELL", "python3 -c 'import socket; s=socket.create_connection((\"127.0.0.1\",8080),2)' "]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  bd-central:
+    <<: *bd-app
+    command:
+      - gunicorn
+      - "-w"
+      - "4"
+      - "-b"
+      - "0.0.0.0:8081"
+      - "--access-logfile"
+      - "-"
+      - "CentralService:app"
+    depends_on:
+      mongo:      { condition: service_healthy }
+      redis:      { condition: service_healthy }
+      influxdb:   { condition: service_healthy }
+      rabbitmq:   { condition: service_healthy }
+      bd-replica: { condition: service_healthy }
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c 'import urllib.request; urllib.request.urlopen(\"http://127.0.0.1:8081/auth/login\", timeout=2)' "]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  bd-data:
+    <<: *bd-app
+    command:
+      - gunicorn
+      - "-w"
+      - "4"
+      - "--timeout"
+      - "120"
+      - "-b"
+      - "0.0.0.0:8082"
+      - "--access-logfile"
+      - "-"
+      - "DataService:app"
+    depends_on:
+      mongo:      { condition: service_healthy }
+      redis:      { condition: service_healthy }
+      influxdb:   { condition: service_healthy }
+      rabbitmq:   { condition: service_healthy }
+      bd-replica: { condition: service_healthy }
+    healthcheck:
+      test: ["CMD-SHELL", "python3 -c 'import socket; s=socket.create_connection((\"127.0.0.1\",8082),2)' "]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    depends_on:
+      bd-central: { condition: service_healthy }
+      bd-data:    { condition: service_healthy }
+    ports:
+      - "${HOST_PORT_CS:-81}:81"
+      - "${HOST_PORT_DS:-82}:82"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certs:/etc/nginx/certs:ro   # Tailscale-issued bd.crt / bd.key (see refresh-cert.sh)
+
+  # Dev SMTP catcher. CentralService sends signup/reset mail here (SMTP 1025);
+  # read the captured messages, including temp passwords, at http://localhost:8025.
+  # Dev only — not a real relay.
+  mailpit:
+    image: axllent/mailpit
+    restart: unless-stopped
+    ports:
+      - "8025:8025"
+
+volumes:
+  mongo-data:
+  redis-data:
+  influx-data:
+  rabbit-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Render bd_settings.cfg + CentralReplica/config.py from env at container
+# start, then exec the per-service command. Doing it here (not at build
+# time) keeps secrets out of the image.
+set -euo pipefail
+
+: "${SECRET_KEY:?required}"
+: "${MONGO_USER:?required}"
+: "${MONGO_PWD:?required}"
+: "${INFLUX_USER:?required}"
+: "${INFLUX_PWD:?required}"
+: "${INFLUX_DB:?required}"
+: "${REDIS_PWD:?required}"
+: "${RABBIT_ADMIN_USER:?required}"
+: "${RABBIT_ADMIN_PWD:?required}"
+: "${RABBIT_END_USER:?required}"
+: "${RABBIT_END_PWD:?required}"
+
+cat >"$BD_SETTINGS" <<EOF
+DEBUG = False
+SECRET_KEY = '$SECRET_KEY'
+TOKEN_EXPIRATION = 3600
+EMAIL = 'LOCAL'
+EMAIL_ID = 'admin@buildingdepot.org'
+SMTP_HOST = '${SMTP_HOST:-localhost}'
+SMTP_PORT = ${SMTP_PORT:-25}
+NOTIFICATION_TYPE = 'RabbitMQ'
+
+MONGODB_HOST = 'mongo'
+MONGODB_PORT = 27017
+MONGODB_DATABASE = 'buildingdepot'
+MONGODB_DATABASE_DS = 'dataservice'
+MONGODB_DATABASE_BD = 'buildingdepot'
+MONGODB_USERNAME = '$MONGO_USER'
+MONGODB_PWD = '$MONGO_PWD'
+
+REDIS_HOST = 'redis'
+REDIS_PWD = '$REDIS_PWD'
+
+NAME = 'ds1'
+
+INFLUXDB_HOST = 'influxdb'
+INFLUXDB_PORT = 8086
+INFLUXDB_DB = '$INFLUX_DB'
+INFLUXDB_USERNAME = '$INFLUX_USER'
+INFLUXDB_PWD = '$INFLUX_PWD'
+
+RABBITMQ_HOST = 'rabbitmq'
+RABBITMQ_ADMIN_USERNAME = '$RABBIT_ADMIN_USER'
+RABBITMQ_ADMIN_PWD = '$RABBIT_ADMIN_PWD'
+RABBITMQ_ENDUSER_USERNAME = '$RABBIT_END_USER'
+RABBITMQ_ENDUSER_PWD = '$RABBIT_END_PWD'
+EOF
+
+# CentralReplica imports plain `from config import Config` — no Flask
+# settings file. Overwrite its module-level config.py from env.
+cat >/app/buildingdepot/CentralReplica/config.py <<EOF
+class Config:
+    MONGODB_DATABASE = "buildingdepot"
+    MONGODB_HOST = "mongo"
+    MONGODB_PORT = 27017
+    SECRET_KEY = "$SECRET_KEY"
+    TOKEN_EXPIRATION = 3600
+    REDIS_HOST = "redis"
+    MONGODB_USERNAME = "$MONGO_USER"
+    MONGODB_PWD = "$MONGO_PWD"
+    REDIS_PWD = "$REDIS_PWD"
+EOF
+
+# Legacy CS + DS hardcode the CentralReplica's XML-RPC client to localhost.
+# In our compose stack the replica is its own container — patch the URL.
+sed -i 's|ServerProxy("http://127.0.0.1:8080")|ServerProxy("http://bd-replica:8080")|' \
+    /app/buildingdepot/DataService/app/__init__.py
+sed -i 's|ServerProxy("http://localhost:8080")|ServerProxy("http://bd-replica:8080")|' \
+    /app/buildingdepot/CentralService/app/__init__.py
+
+exec "$@"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,46 @@
+events {}
+http {
+  proxy_read_timeout 120s;
+  proxy_send_timeout 120s;
+
+  upstream cs { server bd-central:8081; }
+  upstream ds { server bd-data:8082; }
+
+  # TLS terminated here. nginx only reads bd.crt / bd.key; the issuer is up to
+  # refresh-cert.sh -- Let's Encrypt (public IP) or Tailscale (private). Clients
+  # keep using https://<host>:81 (CS) and https://<host>:82 (DS).
+  ssl_certificate     /etc/nginx/certs/bd.crt;
+  ssl_certificate_key /etc/nginx/certs/bd.key;
+  ssl_protocols       TLSv1.2 TLSv1.3;
+
+  server {
+    listen 81 ssl;
+    # Friendly redirect if a plain-HTTP request hits the TLS port.
+    error_page 497 =301 https://$host:$server_port$request_uri;
+    add_header Access-Control-Allow-Origin  '*' always;
+    add_header Access-Control-Allow-Headers 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Charset,Authorization' always;
+    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE' always;
+    location / {
+      proxy_pass http://cs;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+  }
+
+  server {
+    listen 82 ssl;
+    error_page 497 =301 https://$host:$server_port$request_uri;
+    add_header Access-Control-Allow-Origin  '*' always;
+    add_header Access-Control-Allow-Headers 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Charset,Authorization' always;
+    add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS, PUT, DELETE' always;
+    location / {
+      proxy_pass http://ds;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+    }
+  }
+}

--- a/docker/rabbitmq-enabled-plugins
+++ b/docker/rabbitmq-enabled-plugins
@@ -1,0 +1,1 @@
+[rabbitmq_management,rabbitmq_web_stomp,rabbitmq_auth_backend_http,rabbitmq_auth_backend_cache].

--- a/docker/rabbitmq.conf
+++ b/docker/rabbitmq.conf
@@ -1,0 +1,32 @@
+# Dev TLS for web-STOMP so browsers can connect over wss.
+#
+# The cert is the same Tailscale-issued bd.crt / bd.key that nginx serves on
+# 81/82, mounted from docker/certs. Server-side TLS only: no client certs, so
+# no cacertfile and no peer verification. Browsers validate bd.crt against the
+# public CA (it is Let's Encrypt backed).
+#
+# Plain web-STOMP stays on 15674 for in-network use; browsers use wss on 15675.
+# The certfile is the full chain that `tailscale cert` writes, which is what
+# RabbitMQ sends to the client during the handshake.
+web_stomp.ssl.port     = 15675
+web_stomp.ssl.certfile = /etc/rabbitmq/certs/bd.crt
+web_stomp.ssl.keyfile  = /etc/rabbitmq/certs/bd.key
+
+# --- Authentication and authorization ---
+# Two backends, tried in order. Internal users (bdadmin: ops and the ingest
+# publisher) authenticate and authorize via the internal backend. Everyone else
+# presents a BuildingDepot OAuth token as the password; the HTTP backend asks
+# CentralService to validate it and authorize per sensor. Decisions are cached
+# briefly so BD is not called on every operation. Adding the HTTP backend does
+# not change internal users; it is purely additive. See docs/rabbitmq-auth.md.
+auth_backends.1 = internal
+auth_backends.2 = cache
+
+auth_cache.cached_backend = http
+auth_cache.cache_ttl      = 30000
+
+auth_http.http_method   = post
+auth_http.user_path     = http://bd-central:8081/rabbitmq/user
+auth_http.vhost_path    = http://bd-central:8081/rabbitmq/vhost
+auth_http.resource_path = http://bd-central:8081/rabbitmq/resource
+auth_http.topic_path    = http://bd-central:8081/rabbitmq/topic

--- a/docker/refresh-cert.sh
+++ b/docker/refresh-cert.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Provision/renew the TLS cert nginx serves on CS:81 / DS:82, then reload nginx.
+#
+# nginx only ever reads certs/bd.crt + certs/bd.key. This script fills those two
+# files from one of two issuers, picked by CERT_PROVIDER:
+#
+#   certbot    -- PUBLIC IP + real domain. Let's Encrypt via certbot (HTTP-01 on
+#                 :80). Needs the domain's A record -> this host and port 80 free.
+#                 certbot installs its own renewal timer; point its --deploy-hook
+#                 at this script so renewals recopy the PEMs and reload nginx.
+#
+#   tailscale  -- PRIVATE / no public IP (default). Cert from Tailscale for the
+#                 node's MagicDNS name, Let's Encrypt backed, validated over the
+#                 ts.net DNS. Re-run on a daily timer to renew.
+#
+# Usage:
+#   sudo ./refresh-cert.sh                                                  # tailscale, auto domain
+#   sudo BD_CERT_DOMAIN=bd.example.com CERT_PROVIDER=certbot ./refresh-cert.sh
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+CERT_DIR="$DIR/certs"
+PROVIDER="${CERT_PROVIDER:-tailscale}"
+mkdir -p "$CERT_DIR"
+
+# Fingerprint the current cert so we only bounce services on a real renewal.
+OLD_HASH="$([ -f "$CERT_DIR/bd.crt" ] && sha256sum "$CERT_DIR/bd.crt" | cut -d' ' -f1 || echo none)"
+
+case "$PROVIDER" in
+  certbot)
+    : "${BD_CERT_DOMAIN:?set BD_CERT_DOMAIN to your public domain}"
+    echo "[certbot] obtaining/renewing Let's Encrypt cert for $BD_CERT_DOMAIN"
+    args=(certonly --standalone --non-interactive --agree-tos -d "$BD_CERT_DOMAIN")
+    if [ -n "${CERTBOT_EMAIL:-}" ]; then args+=(-m "$CERTBOT_EMAIL"); else args+=(--register-unsafely-without-email); fi
+    certbot "${args[@]}"
+    LE="/etc/letsencrypt/live/$BD_CERT_DOMAIN"
+    cp "$LE/fullchain.pem" "$CERT_DIR/bd.crt"
+    cp "$LE/privkey.pem"   "$CERT_DIR/bd.key"
+    ;;
+
+  tailscale)
+    DOMAIN="${BD_CERT_DOMAIN:-$(tailscale status --json | python3 -c 'import sys,json; print(json.load(sys.stdin)["CertDomains"][0])')}"
+    echo "[tailscale] issuing/renewing cert for $DOMAIN"
+    tailscale cert --cert-file "$CERT_DIR/bd.crt" --key-file "$CERT_DIR/bd.key" "$DOMAIN"
+    ;;
+
+  *)
+    echo "unknown CERT_PROVIDER: $PROVIDER (use certbot|tailscale)" >&2
+    exit 1
+    ;;
+esac
+
+# nginx runs as root and reads the 0600 key fine, but the RabbitMQ node runs as
+# the unprivileged 'rabbitmq' user, so the key must be world-readable for the
+# web-STOMP TLS listener (15675) to start. Acceptable on a single-user host.
+chmod 0644 "$CERT_DIR/bd.crt" "$CERT_DIR/bd.key"
+
+# Only reload if the cert actually changed, so a daily timer is a no-op until a
+# real renewal and does not bounce the broker every day.
+NEW_HASH="$(sha256sum "$CERT_DIR/bd.crt" | cut -d' ' -f1)"
+if [ "$NEW_HASH" = "$OLD_HASH" ]; then
+  echo "cert unchanged, nothing to reload."
+  exit 0
+fi
+
+# nginx (81/82) reloads in place; fall back to a recreate if it is not up yet.
+if docker compose -f "$DIR/docker-compose.yml" exec -T nginx nginx -s reload 2>/dev/null; then
+  echo "nginx reloaded."
+else
+  docker compose -f "$DIR/docker-compose.yml" up -d --force-recreate nginx
+  echo "nginx (re)started."
+fi
+
+# RabbitMQ loads its TLS cert when the listener starts, so it needs a restart to
+# pick up a renewed cert for web-STOMP on 15675.
+docker compose -f "$DIR/docker-compose.yml" restart rabbitmq 2>/dev/null && echo "rabbitmq restarted." || true

--- a/docker/refresh-cert.sh
+++ b/docker/refresh-cert.sh
@@ -51,9 +51,12 @@ case "$PROVIDER" in
 esac
 
 # nginx runs as root and reads the 0600 key fine, but the RabbitMQ node runs as
-# the unprivileged 'rabbitmq' user, so the key must be world-readable for the
-# web-STOMP TLS listener (15675) to start. Acceptable on a single-user host.
-chmod 0644 "$CERT_DIR/bd.crt" "$CERT_DIR/bd.key"
+# the unprivileged 'rabbitmq' user, so the key must be readable by that UID/GID.
+# Prefer group-read rather than world-read; override the GID if your image differs.
+RABBITMQ_CERT_GID="${RABBITMQ_CERT_GID:-999}"
+chown :"$RABBITMQ_CERT_GID" "$CERT_DIR/bd.key" 2>/dev/null || true
+chmod 0644 "$CERT_DIR/bd.crt"
+chmod 0640 "$CERT_DIR/bd.key"
 
 # Only reload if the cert actually changed, so a daily timer is a no-op until a
 # real renewal and does not bounce the broker every day.


### PR DESCRIPTION
Adds a `docker/` directory that runs BuildingDepot's three processes (CentralReplica, CentralService, DataService) from a single image alongside Mongo, InfluxDB 1.8, Redis, RabbitMQ, nginx (TLS termination on 81/82), and a Mailpit dev mail catcher.

## Highlights
- one image, three commands via a compose YAML anchor
- secrets rendered at container start from `.env` (nothing baked into the image)
- entrypoint rewrites legacy `localhost` XML-RPC URLs to the `bd-replica` container
- health-gated startup ordering
- `bootstrap_admin.sh` creates the super user + registers the `ds1` data service
- `refresh-cert.sh` issues TLS certs via Let's Encrypt or Tailscale
- RabbitMQ exposed to the host (AMQP + web-STOMP) for external live consumers

`IMPLEMENTATION.md` explains the design; `README.md` covers TLS and mail.

## Notes
- Foundational PR — merge first; subsequent config/feature PRs build on this stack.
- No application code changes; this only adds the `docker/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)