### PR TITLE
DataService: make RabbitMQ broker host configurable

### DIFF
--- a/buildingdepot/DataService/app/__init__.py
+++ b/buildingdepot/DataService/app/__init__.py
@@ -32,7 +32,7 @@ app.config.from_envvar("BD_SETTINGS")
 permissions = {"rw": "r/w", "r": "r", "dr": "d/r", "rwp": "r/w/p"}
 
 exchange = 'master_exchange'
-rabbitmq_host = app.config['RABBITMQ_HOST']
+rabbitmq_host = app.config.get("RABBITMQ_HOST", "localhost")
 rabbitmq_username = app.config['RABBITMQ_ADMIN_USERNAME']
 rabbitmq_password = app.config['RABBITMQ_ADMIN_PWD']
 

--- a/buildingdepot/DataService/app/__init__.py
+++ b/buildingdepot/DataService/app/__init__.py
@@ -32,6 +32,7 @@ app.config.from_envvar("BD_SETTINGS")
 permissions = {"rw": "r/w", "r": "r", "dr": "d/r", "rwp": "r/w/p"}
 
 exchange = 'master_exchange'
+rabbitmq_host = app.config['RABBITMQ_HOST']
 rabbitmq_username = app.config['RABBITMQ_ADMIN_USERNAME']
 rabbitmq_password = app.config['RABBITMQ_ADMIN_PWD']
 

--- a/buildingdepot/DataService/app/rest_api/helper.py
+++ b/buildingdepot/DataService/app/rest_api/helper.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from flask import request, abort
 from functools import wraps
 
-from .. import exchange, r, rabbitmq_username, rabbitmq_password
+from .. import exchange, r, rabbitmq_host, rabbitmq_username, rabbitmq_password
 from ..models.ds_models import Building, TagType, User
 from ..auth.views import Token
 
@@ -168,7 +168,7 @@ def connect_broker():
     try:
         credentials = pika.PlainCredentials(rabbitmq_username, rabbitmq_password)
         parameters = pika.ConnectionParameters(
-            host="localhost",
+            host=rabbitmq_host,
             credentials=credentials,
             connection_attempts=3,
             retry_delay=5,


### PR DESCRIPTION
Read the broker host from the `RABBITMQ_HOST` setting instead of hardcoding `"localhost"`, so DataService can reach a broker running on another host or container.

- `DataService/app/__init__.py`: `rabbitmq_host = app.config['RABBITMQ_HOST']`
- `DataService/app/rest_api/helper.py`: `connect_broker()` uses `rabbitmq_host`

Merge order: after #131 (docker stack). The docker stack relies on this to point DataService at the `rabbitmq` container.

Note: uses `app.config['RABBITMQ_HOST']` (raises if unset). If you'd prefer it backward-compatible for existing deployments, say so and I'll switch to `app.config.get("RABBITMQ_HOST", "localhost")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)