### PR TITLE
CentralService: make registration-mail SMTP host/port configurable

### DIFF
--- a/buildingdepot/CentralService/app/rest_api/helper.py
+++ b/buildingdepot/CentralService/app/rest_api/helper.py
@@ -79,11 +79,15 @@ def send_local_smtp(user_name, to_email, password):
     )
 
     try:
-        smtpObj = smtplib.SMTP(
-            current_app.config.get("SMTP_HOST", "localhost"),
-            current_app.config.get("SMTP_PORT", 25),
-        )
-        smtpObj.sendmail(sender, receivers, message)
+        smtp_host = current_app.config.get("SMTP_HOST", "localhost")
+        smtp_port = current_app.config.get("SMTP_PORT", 25)
+        try:
+            smtp_port = int(smtp_port)
+        except (TypeError, ValueError):
+            smtp_port = 25
+
+        with smtplib.SMTP(smtp_host, smtp_port) as smtpObj:
+            smtpObj.sendmail(sender, receivers, message)
     except smtplib.SMTPException:
         print(("Failed to send registration mail to %s" % (to_email)))
 

--- a/buildingdepot/CentralService/app/rest_api/helper.py
+++ b/buildingdepot/CentralService/app/rest_api/helper.py
@@ -79,7 +79,10 @@ def send_local_smtp(user_name, to_email, password):
     )
 
     try:
-        smtpObj = smtplib.SMTP("localhost")
+        smtpObj = smtplib.SMTP(
+            current_app.config.get("SMTP_HOST", "localhost"),
+            current_app.config.get("SMTP_PORT", 25),
+        )
         smtpObj.sendmail(sender, receivers, message)
     except smtplib.SMTPException:
         print(("Failed to send registration mail to %s" % (to_email)))


### PR DESCRIPTION
Read `SMTP_HOST`/`SMTP_PORT` from config (defaulting to `localhost:25`) in `send_local_smtp`, instead of hardcoding the local mailer, so signup/reset mail can go through an external SMTP server or a dev mail catcher. Behavior is unchanged when the settings are unset.

- `CentralService/app/rest_api/helper.py`

Merge order: after #131 (docker stack). The docker stack points this at the Mailpit dev catcher via `SMTP_HOST`/`SMTP_PORT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)