### PR TITLE
auth: authorize RabbitMQ clients with BD OAuth tokens via HTTP auth backend

### DIFF
--- a/buildingdepot/CentralService/app/__init__.py
+++ b/buildingdepot/CentralService/app/__init__.py
@@ -86,6 +86,10 @@ def create_app(config_mode):  # TODO: remove config_mode
 
     app.register_blueprint(oauth_bd_blueprint, url_prefix="/oauth")
 
+    from .rabbitmq_auth import rabbitmq_auth as rabbitmq_auth_blueprint
+
+    app.register_blueprint(rabbitmq_auth_blueprint, url_prefix="/rabbitmq")
+
     return app
 
 

--- a/buildingdepot/CentralService/app/rabbitmq_auth/__init__.py
+++ b/buildingdepot/CentralService/app/rabbitmq_auth/__init__.py
@@ -1,0 +1,75 @@
+"""RabbitMQ HTTP auth backend.
+
+Lets RabbitMQ authenticate and authorize clients with a BuildingDepot OAuth
+token instead of a broker password. The rabbitmq_auth_backend_http plugin POSTs
+to the four endpoints below, and each replies with the literal text "allow" or
+"deny" by reusing BD's own token validation (user_for_token) and per-sensor ACL
+(permission). One token, one authority: BD.
+
+Only token-bearing consumers reach these routes. Internal users (the bdadmin
+publisher and ops) authenticate via RabbitMQ's own internal backend and are
+never sent here.
+
+Wiring lives in docker/rabbitmq.conf. Design and rationale in
+docs/rabbitmq-auth.md.
+"""
+
+from flask import Blueprint, request
+
+from ..auth.access_control import permission
+from ..rest_api.helper import user_for_token
+
+rabbitmq_auth = Blueprint("rabbitmq_auth", __name__)
+
+# DataService publishes live sensor data here, keyed by sensor_id.
+LIVE_EXCHANGE = "master_exchange"
+# permission() levels that include read access.
+READ_LEVELS = {"r/w/p", "r/w", "r"}
+
+
+def _reply(allowed):
+    return ("allow" if allowed else "deny"), 200, {"Content-Type": "text/plain"}
+
+
+@rabbitmq_auth.route("/user", methods=["POST"])
+def user():
+    """Authenticate. The password is a BD token; bind the connection's username
+    to the token's real owner so later resource/topic checks can trust it."""
+    username = request.form.get("username", "")
+    email = user_for_token(request.form.get("password", ""))
+    return _reply(email is not None and email == username)
+
+
+@rabbitmq_auth.route("/vhost", methods=["POST"])
+def vhost():
+    return _reply(request.form.get("vhost") == "/")
+
+
+@rabbitmq_auth.route("/resource", methods=["POST"])
+def resource():
+    """Consumers read the live exchange and manage their own transient
+    subscription queues. Publishing and declaring are left to the internal
+    user, so any other resource access is denied here."""
+    res = request.form.get("resource")
+    name = request.form.get("name")
+    perm = request.form.get("permission")
+    if res == "queue":
+        return _reply(True)
+    if res == "exchange" and name == LIVE_EXCHANGE:
+        return _reply(perm == "read")
+    return _reply(False)
+
+
+@rabbitmq_auth.route("/topic", methods=["POST"])
+def topic():
+    """The per-sensor gate. A routing_key is a sensor_id, which is the
+    Sensor.name in BD, so we allow a read only when BD's ACL grants this user
+    read on that sensor."""
+    if (
+        request.form.get("permission") != "read"
+        or request.form.get("name") != LIVE_EXCHANGE
+    ):
+        return _reply(False)
+    email = request.form.get("username", "")
+    routing_key = request.form.get("routing_key", "")
+    return _reply(permission(routing_key, email=email) in READ_LEVELS)

--- a/buildingdepot/CentralService/app/rest_api/helper.py
+++ b/buildingdepot/CentralService/app/rest_api/helper.py
@@ -315,33 +315,35 @@ def get_sg_ds(sensor_group):
     # return DataService.objects(buildings__contains=sg.building).first().name
 
 
+def user_for_token(access_token):
+    """Resolve an OAuth access token to its user email, or None if the token is
+    missing, unknown, or expired. Redis cache first, then Mongo (refreshing the
+    cache). Token validation lives here so check_oauth and the RabbitMQ auth
+    backend share exactly one implementation."""
+    if not access_token:
+        return None
+    user = r.get("".join(["oauth:", access_token]))
+    if user is not None:
+        return user
+    # Not in Redis, check MongoDB.
+    token = Token.objects(access_token=access_token).first()
+    if token:
+        expires_in = (token.expires - datetime.now()).total_seconds()
+        if expires_in > 0:
+            r.setex("".join(["oauth:", access_token]), int(expires_in), token.user)
+            return token.user
+        token.delete()
+    return None
+
+
 def check_oauth(f):
     @wraps(f)
     def secure(*args, **kwargs):
-        if not request.headers.get("Authorization"):
+        auth = request.headers.get("Authorization")
+        if not auth:
             abort(401)
-        access_token = request.headers.get("Authorization")[7:]
-        if request.headers.get("Authorization") is not None:
-            user = r.get("".join(["oauth:", access_token]))
-            if user is not None:
-                return f(*args, **kwargs)
-            else:
-                # Not found in Redis, checking in MongoDB
-                token = Token.objects(access_token=access_token).first()
-                if token:
-                    # Calculate time to expire in seconds using timedelta
-                    expires_in = (token.expires - datetime.now()).total_seconds()
-                    if expires_in > 0:
-                        # Still valid, adding to redis
-                        r.setex(
-                            "".join(["oauth:", access_token]),
-                            int(expires_in),
-                            token.user,
-                        )
-                        return f(*args, **kwargs)
-                    else:
-                        # Invalid, deleting
-                        token.delete()
+        if user_for_token(auth[7:]) is not None:
+            return f(*args, **kwargs)
         abort(401)
 
     return secure

--- a/buildingdepot/DataService/app/rest_api/helper.py
+++ b/buildingdepot/DataService/app/rest_api/helper.py
@@ -175,8 +175,11 @@ def connect_broker():
         )
         pubsub = pika.BlockingConnection(parameters)
         channel = pubsub.channel()
+        # Topic (not direct) so RabbitMQ runs its per-routing-key authorization
+        # callback, which lets the BD auth backend gate reads per sensor_id.
+        # Exact sensor_id keys match identically on a topic exchange.
         channel.exchange_declare(
-            exchange=exchange, exchange_type="direct", durable=True
+            exchange=exchange, exchange_type="topic", durable=True
         )
         channel.close()
         return pubsub

--- a/docs/rabbitmq-auth.md
+++ b/docs/rabbitmq-auth.md
@@ -1,0 +1,71 @@
+# RabbitMQ access control: BD token as the broker credential
+
+## The problem
+
+Dashboards and services consume BuildingDepot's live sensor fan-out from RabbitMQ. The old approach shipped one shared broker username and password to every client, including the browser, where any visitor could read it from the page. A read-only role would shrink the blast radius but a shared static secret in the browser is still wrong, and it puts authorization in the broker's user list rather than in BD, which is the real authority over who may see which sensor.
+
+We also cannot solve this with a stateful proxy on the UI server, and we do not want to mint a second family of tokens. The UI already holds a BD token that grants the user everything they own. The right design is to let that same token authenticate to RabbitMQ, with BD deciding access. One token, one authority, one point of access.
+
+## The decision
+
+RabbitMQ authenticates clients with a BD OAuth token instead of a broker password, and delegates every authorization decision to BD. A client connects with its email as the login and its BD token as the passcode. RabbitMQ asks CentralService to validate the token and to authorize each resource and each sensor. BD answers from the same ACL it already uses for its HTTP API.
+
+This uses RabbitMQ's first-party `rabbitmq_auth_backend_http` plugin, with `rabbitmq_auth_backend_cache` in front so BD is not called on every operation.
+
+### Why not JWT / oauth2
+
+The oauth2 backend validates signed JWTs locally. BD tokens are opaque random strings stored in Mongo and cached in Redis, not JWTs (`check_oauth` in `CentralService/app/rest_api/helper.py`). So the broker cannot verify them on its own, it has to ask BD. The HTTP backend is exactly that delegation, and it reuses the BD token as-is with no reformatting.
+
+### Additive, not destructive
+
+The backends run as an ordered chain: `internal` then the cached HTTP backend. RabbitMQ tries them in order, and the first backend that authenticates a user also authorizes it. So `bdadmin` (broker ops and the ingest publisher) authenticates against the internal backend and never reaches BD, exactly as before. Only token-bearing consumers fall through to the HTTP backend. Enabling this changes nothing about existing internal users, and removing it from the chain reverts cleanly.
+
+## How it works
+
+RabbitMQ POSTs to four CentralService endpoints under `/rabbitmq`, each returning the literal text `allow` or `deny`.
+
+- **user** receives the email (username) and the BD token (password). It resolves the token to its owner and allows only when the owner matches the supplied username, which binds the connection's identity to the real token owner so later checks can trust the username.
+- **vhost** allows the single `/` vhost.
+- **resource** lets a consumer read the `master_exchange` and fully manage its own transient subscription queues. Publishing and declaring the exchange are left to the internal user, so everything else is denied.
+- **topic** is the per-sensor gate. RabbitMQ calls it with the routing key, which is the `sensor_id`, which is the `Sensor.name` in BD. It allows a read only when BD's ACL grants this user read on that sensor.
+
+Two pieces of BD logic are reused rather than reimplemented: `user_for_token` (the Redis-then-Mongo token resolver, factored out of `check_oauth` so validation lives in one place) and `permission(sensor, email)` (the full per-sensor ACL, covering ownership, dataservice admins, and shared sensor and user groups).
+
+### Topic exchange
+
+Per-sensor authorization only works if `master_exchange` is a `topic` exchange, because RabbitMQ runs its per-routing-key authorization callback only for topic exchanges. The publisher now declares it `topic`. Exact `sensor_id` keys carry no wildcards, so they match identically to the previous `direct` behavior, and subscribers are unaffected.
+
+### The dependency it adds
+
+RabbitMQ now needs `bd-central` reachable to authorize new connections and uncached topic checks. The cache softens this, and BD is already a hard dependency for the whole stack, so this is acceptable. Internal users still work if BD is down.
+
+## Implementation
+
+New code is contained in one place: a single blueprint, `CentralService/app/rabbitmq_auth/__init__.py`, holding the four endpoints. Everything else is small, surgical edits.
+
+| Change | File |
+|---|---|
+| The four auth endpoints | `CentralService/app/rabbitmq_auth/__init__.py` (new) |
+| Register the blueprint at `/rabbitmq` | `CentralService/app/__init__.py` |
+| Factor `user_for_token` out of `check_oauth` for reuse | `CentralService/app/rest_api/helper.py` |
+| Publish to a `topic` exchange | `DataService/app/rest_api/helper.py` |
+| Enable the two auth plugins | `docker/rabbitmq-enabled-plugins` |
+| Backend chain, cache, and the four endpoint URLs | `docker/rabbitmq.conf` |
+
+The endpoints are unauthenticated at the Flask layer because RabbitMQ calls them and they validate the passed token themselves. They are reached internally at `http://bd-central:8081/rabbitmq/*`, never through nginx, so in production they should stay on the internal network.
+
+### Verification
+
+Tested by connecting with a real BD token and attempting to bind a queue to `master_exchange`:
+
+- read a sensor the user owns: allowed
+- read a routing key the user does not own: denied at the topic check
+- a bad token: connection refused at the user check
+- a valid token but a mismatched username: refused, so a token cannot be replayed under another identity
+- `bdadmin` over the internal backend: unaffected
+
+CentralService logged the matching `/rabbitmq/user`, `/vhost`, `/resource`, and `/topic` callbacks, confirming RabbitMQ delegated each decision to BD.
+
+## Future: variable-TTL tokens for background work
+
+Not implemented, captured here so the design accounts for it. Today a consumer's access is only as durable as the user's token. Background work — for example a long-running analytics or aggregation job — needs to keep a live subscription running after the user has gone away. The plan is for the control plane to mint tokens with a longer, bounded TTL scoped to the relevant sensors, so a background job can hold a valid subscription without a human present, while interactive sessions keep using the user's normal short-lived token. Nothing in the current backend has to change to support this: the same `user_for_token` plus `permission` path authorizes whatever token is presented. The work is in issuing and scoping those tokens, which belongs to the next phase.


### PR DESCRIPTION
Lets RabbitMQ authenticate and authorize clients with a BuildingDepot OAuth token instead of a broker password, reusing BD's own token validation and per-sensor ACL. The `rabbitmq_auth_backend_http` plugin POSTs to four endpoints that each reply `allow`/`deny`; one token, one authority: BD.

## Changes
- new CentralService blueprint `app/rabbitmq_auth` (mounted at `/rabbitmq`)
- extract token validation into `user_for_token()` in `rest_api/helper.py` so `check_oauth` and the RabbitMQ backend share one implementation
- DataService declares the live exchange as a **topic** exchange so RabbitMQ runs its per-routing-key authorization callback (gating reads per `sensor_id`)
- `docs/rabbitmq-auth.md`

The broker-side wiring (`rabbitmq.conf`, enabled plugins) ships with the docker stack (#131). RabbitMQ tries its internal backend first, so existing internal users (`bdadmin`) are unaffected; only token-bearing consumers fall through to the HTTP backend. Additive and reverts cleanly.

Merge order: last of this set (after #131, #132, #133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)