### PR TITLE
rabitmq ssl also handled by nginx

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -77,7 +77,7 @@ Reach BD at `https://<node>.<tailnet>.ts.net:81` / `:82`. Certs are 90-day; run 
 
 ### Live data over wss (RabbitMQ web-STOMP)
 
-Browsers stream live sensor data over web-STOMP, and an `https://` page can only open a `wss://` socket. RabbitMQ serves that on **15675** using the same `certs/bd.crt` / `bd.key`, configured in `rabbitmq.conf`. Plain `ws://` stays on 15674 for in-network use. nginx runs as root so it can read the private key, but the RabbitMQ node runs as the unprivileged `rabbitmq` user, so `refresh-cert.sh` makes the key group-readable (`0640`) and sets its group to RabbitMQ’s container GID (default `999`, override via `RABBITMQ_CERT_GID`). Point the UI at `wss://<node>.<tailnet>.ts.net:15675/ws` (`PUBLIC_RABBITMQ_HOSTNAME` = the node name, `PUBLIC_RABBITMQ_PORT` = 15675).
+Browsers stream live sensor data over web-STOMP, and an `https://` page can only open a `wss://` socket. **nginx terminates that TLS on 15675** and proxies to RabbitMQ's plain web-STOMP listener on **15674** (`nginx.conf`); the broker itself speaks only plain `ws`. This keeps a single TLS termination point and, deliberately, keeps the private key out of the broker: nginx already reads `certs/bd.crt` / `bd.key` as root, whereas the RabbitMQ node runs as the unprivileged `rabbitmq` user — handing it the key would mean either a world-readable key or fighting the container-user/host-user UID mapping (which differs between Docker and rootless Podman). Plain `ws://` on 15674 stays available for in-network use. Point the UI at `wss://<node>.<tailnet>.ts.net:15675/ws` (`PUBLIC_RABBITMQ_HOSTNAME` = the node name, `PUBLIC_RABBITMQ_PORT` = 15675).
 
 ## RabbitMQ access (BD token as the broker credential)
 
@@ -101,6 +101,46 @@ Two setup-flow notes:
 - **Token auth needs `bd-central` reachable.** RabbitMQ calls CentralService to authorize, with a short cache. Internal users (`bdadmin`) keep working even if BD is down; token users cannot connect until BD is up. There is no compose `depends_on` from rabbitmq to bd-central (that would be a cycle), and none is needed since auth happens on client connect, by which point BD is up.
 
 Design and rationale: `docs/rabbitmq-auth.md`.
+
+## Running under rootless Podman
+
+The stack also runs under rootless Podman (via `podman-docker`, so the `docker compose` commands above work unchanged). Two host-level adjustments are needed because rootless containers run in a user namespace.
+
+### 1. Network backend — use slirp4netns instead of pasta
+
+Podman's default rootless network helper is `pasta`. On some distros the packaged `passt`/`pasta` binary segfaults at startup (seen on Ubuntu *resolute* with glibc 2.43 and the `git20260120` passt snapshot — `pasta --version` itself crashes), which makes every container fail at the networking step:
+
+```
+Error response from daemon: setting up Pasta: pasta failed with exit code -1
+```
+
+Switch the rootless backend to `slirp4netns` (Podman's previous default; fully supported, just slightly lower throughput). Create `~/.config/containers/containers.conf`:
+
+```ini
+[network]
+default_rootless_network_cmd = "slirp4netns"
+```
+
+Then `docker compose up -d` works. This is a per-user setting. Once a fixed `passt` lands (`apt upgrade passt`), you can delete this override to go back to pasta.
+
+### 2. Privileged ports (81/82)
+
+Rootless containers cannot bind host ports below 1024, so publishing CS/DS on **81/82** fails with:
+
+```
+rootlessport cannot expose privileged port 81 ... bind: permission denied
+```
+
+Pick one:
+
+- **Lower the threshold (keeps the :81/:82 URLs).** Persist it so it survives reboots:
+  ```bash
+  echo 'net.ipv4.ip_unprivileged_port_start=80' | sudo tee /etc/sysctl.d/50-bd-ports.conf
+  sudo sysctl --system
+  ```
+  This is host-wide. (`sudo sysctl -w net.ipv4.ip_unprivileged_port_start=80` sets it for the current boot only.)
+
+- **Remap to unprivileged ports (no root, self-contained).** In `.env` set e.g. `HOST_PORT_CS=8081` and `HOST_PORT_DS=8082` (and `HOST_PORT_RABBIT_WSS` ≥ 1024 if you also hit it). Reach BD at `https://<host>:8081` / `:8082` instead. The container-internal ports and `nginx.conf` are unaffected.
 
 ## Notes
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,19 +71,18 @@ services:
       RABBITMQ_DEFAULT_USER: ${RABBIT_ADMIN_USER}
       RABBITMQ_DEFAULT_PASS: ${RABBIT_ADMIN_PWD}
     # Broker reachable from the host so non-container clients (analytics consumers,
-    # a web UI) can consume BD's live fan-out. AMQP for native clients; web-STOMP for websockets.
+    # a web UI) can consume BD's live fan-out. AMQP for native clients; web-STOMP for
+    # websockets. The broker speaks only plain ws (15674); nginx terminates TLS and
+    # proxies browser wss to it (see nginx.conf), so rabbitmq never handles the key.
     ports:
       - "${HOST_PORT_AMQP:-5672}:5672"            # AMQP (e.g. native pika clients)
       - "${HOST_PORT_RABBIT_MGMT:-15672}:15672"   # management UI + HTTP API
       - "${HOST_PORT_RABBIT_WS:-15674}:15674"     # web-STOMP plain ws (in-network)
-      - "${HOST_PORT_RABBIT_WSS:-15675}:15675"    # web-STOMP over TLS (wss: browsers)
     volumes:
       - rabbit-data:/var/lib/rabbitmq
       # Enable web-STOMP (websocket) alongside management; see rabbitmq-enabled-plugins.
       - ./rabbitmq-enabled-plugins:/etc/rabbitmq/enabled_plugins:ro
-      # TLS web-STOMP on 15675 using the Tailscale cert (see rabbitmq.conf).
       - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf:ro
-      - ./certs:/etc/rabbitmq/certs:ro
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
       interval: 10s
@@ -156,9 +155,11 @@ services:
     depends_on:
       bd-central: { condition: service_healthy }
       bd-data:    { condition: service_healthy }
+      rabbitmq:   { condition: service_healthy }
     ports:
       - "${HOST_PORT_CS:-81}:81"
       - "${HOST_PORT_DS:-82}:82"
+      - "${HOST_PORT_RABBIT_WSS:-15675}:15675"   # web-STOMP over TLS (wss); proxied to rabbitmq:15674
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
       - ./certs:/etc/nginx/certs:ro   # Tailscale-issued bd.crt / bd.key (see refresh-cert.sh)

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,6 +5,15 @@ http {
 
   upstream cs { server bd-central:8081; }
   upstream ds { server bd-data:8082; }
+  # Plain web-STOMP listener on the broker; nginx fronts it with TLS (see below).
+  upstream rabbitws { server rabbitmq:15674; }
+
+  # Standard websocket upgrade plumbing: echo a present Upgrade header, send
+  # "close" when absent so non-ws requests on the same server don't hang.
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+  }
 
   # TLS terminated here. nginx only reads bd.crt / bd.key; the issuer is up to
   # refresh-cert.sh -- Let's Encrypt (public IP) or Tailscale (private). Clients
@@ -41,6 +50,25 @@ http {
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+    }
+  }
+
+  # TLS front for web-STOMP. Browsers connect to wss://<host>:15675 (web_stomp
+  # default path /ws); nginx terminates TLS and proxies to the broker's plain ws
+  # on 15674. The broker therefore never reads the key (see rabbitmq.conf).
+  server {
+    listen 15675 ssl;
+    error_page 497 =301 https://$host:$server_port$request_uri;
+    location / {
+      proxy_pass http://rabbitws;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_read_timeout 3600s;   # web-STOMP connections are long-lived
     }
   }
 }

--- a/docker/rabbitmq.conf
+++ b/docker/rabbitmq.conf
@@ -1,16 +1,10 @@
-# Dev TLS for web-STOMP so browsers can connect over wss.
-#
-# The cert is the same Tailscale-issued bd.crt / bd.key that nginx serves on
-# 81/82, mounted from docker/certs. Server-side TLS only: no client certs, so
-# no cacertfile and no peer verification. Browsers validate bd.crt against the
-# public CA (it is Let's Encrypt backed).
-#
-# Plain web-STOMP stays on 15674 for in-network use; browsers use wss on 15675.
-# The certfile is the full chain that `tailscale cert` writes, which is what
-# RabbitMQ sends to the client during the handshake.
-web_stomp.ssl.port     = 15675
-web_stomp.ssl.certfile = /etc/rabbitmq/certs/bd.crt
-web_stomp.ssl.keyfile  = /etc/rabbitmq/certs/bd.key
+# web-STOMP listens on plain ws (15674) only. TLS is terminated by nginx, which
+# proxies browser wss (15675) to this plain listener -- see docker-compose.yml and
+# nginx.conf. Keeping the key out of the broker sidesteps the in-container
+# read-permission problem that differs between rootful Docker (container GID ==
+# host GID) and rootless Podman (IDs remapped to subuids), since the broker runs
+# as the unprivileged rabbitmq user. nginx already holds bd.crt / bd.key and runs
+# as root, so it reads the key cleanly under either engine.
 
 # --- Authentication and authorization ---
 # Two backends, tried in order. Internal users (bdadmin: ops and the ingest

--- a/docker/refresh-cert.sh
+++ b/docker/refresh-cert.sh
@@ -50,13 +50,12 @@ case "$PROVIDER" in
     ;;
 esac
 
-# nginx runs as root and reads the 0600 key fine, but the RabbitMQ node runs as
-# the unprivileged 'rabbitmq' user, so the key must be readable by that UID/GID.
-# Prefer group-read rather than world-read; override the GID if your image differs.
-RABBITMQ_CERT_GID="${RABBITMQ_CERT_GID:-999}"
-chown :"$RABBITMQ_CERT_GID" "$CERT_DIR/bd.key" 2>/dev/null || true
+# Only nginx reads these (it terminates TLS for CS/DS on 81/82 and for RabbitMQ
+# web-STOMP wss on 15675), and its container process runs as root, so owner-only
+# on the key is enough under both rootful Docker and rootless Podman. The cert is
+# public; the key stays 0600.
 chmod 0644 "$CERT_DIR/bd.crt"
-chmod 0640 "$CERT_DIR/bd.key"
+chmod 0600 "$CERT_DIR/bd.key"
 
 # Only reload if the cert actually changed, so a daily timer is a no-op until a
 # real renewal and does not bounce the broker every day.
@@ -66,14 +65,12 @@ if [ "$NEW_HASH" = "$OLD_HASH" ]; then
   exit 0
 fi
 
-# nginx (81/82) reloads in place; fall back to a recreate if it is not up yet.
+# nginx terminates all TLS (CS/DS on 81/82 and web-STOMP wss on 15675), so a
+# renewal only needs nginx to reload. It reloads in place; fall back to a recreate
+# if it is not up yet.
 if docker compose -f "$DIR/docker-compose.yml" exec -T nginx nginx -s reload 2>/dev/null; then
   echo "nginx reloaded."
 else
   docker compose -f "$DIR/docker-compose.yml" up -d --force-recreate nginx
   echo "nginx (re)started."
 fi
-
-# RabbitMQ loads its TLS cert when the listener starts, so it needs a restart to
-# pick up a renewed cert for web-STOMP on 15675.
-docker compose -f "$DIR/docker-compose.yml" restart rabbitmq 2>/dev/null && echo "rabbitmq restarted." || true


### PR DESCRIPTION
Nginx can handle ssl proxying for rabbitmq, like it does for the other services. The main motivation was to work around permissions issues in rootless podman, but generally this approach simplifies certificate management