### PR TITLE
DataService: enforce per-sensor read permission on app subscription

### DIFF
--- a/buildingdepot/DataService/app/rest_api/app_subscription.py
+++ b/buildingdepot/DataService/app/rest_api/app_subscription.py
@@ -19,6 +19,10 @@ from . import responses
 from .helper import connect_broker, get_email, check_oauth
 from .. import r, oauth, exchange
 from ..models.ds_models import Application
+from ..api_0_0.resources.utils import batch_permission_check
+
+# permission() levels that include read access.
+READ_LEVELS = ("r/w/p", "r/w", "r")
 
 
 class AppSubscriptionService(MethodView):
@@ -44,6 +48,13 @@ class AppSubscriptionService(MethodView):
             sensor = json_data["sensor"]
         except Exception as e:
             return jsonify(responses.missing_parameters)
+
+        # Enforce per-sensor read access before binding. The queue is bound to
+        # the sensor server-side over the internal broker connection, so
+        # RabbitMQ's own per-routing-key authorization never runs for this
+        # flow — this is the only place the per-sensor check can happen.
+        if batch_permission_check([sensor], email).get(sensor, "u/d") not in READ_LEVELS:
+            return jsonify(responses.permission_denied)
 
         app_list = Application._get_collection().find({"user": email})[0]["apps"]
         pubsub = connect_broker()

--- a/buildingdepot/DataService/app/rest_api/responses.py
+++ b/buildingdepot/DataService/app/rest_api/responses.py
@@ -22,3 +22,4 @@ queue_binding_failure = {"success": "False", "error": "Failed to bind queue"}
 queue_unbinding_failure = {"success": "False", "error": "Failed to unbind queue"}
 application_does_not_exist = {"success": "False", "error": "Application does not exist"}
 application_does_not_found_for_user = {"success": "False", "error": "No Applications found for user"}
+permission_denied = {"success": "False", "error": "You do not have read permission to this sensor"}


### PR DESCRIPTION
## Problem (authorization bypass)
`POST /api/apps/subscription` binds a sensor's routing key to the caller's app queue after checking only:
- the token is valid (`@check_oauth`), and
- the app/queue belongs to the caller.

It never checks that the caller may **read the sensor**. And because the bind runs server-side over the internal `bdadmin` broker connection, RabbitMQ's own per-routing-key authorization never fires for this flow. Net: any authenticated user can subscribe to — and then stream live data from — sensors they have no permission for.

## Fix
Before binding, check the caller's per-sensor permission via `batch_permission_check` (the same path the timeseries write endpoint uses) and reject with `permission_denied` unless read is granted (`r/w/p`, `r/w`, `r`). Fails closed for unknown/absent sensors.

- `app_subscription.py`: per-sensor read check before `queue_bind`
- `responses.py`: add `permission_denied`

Unsubscribe (`DELETE`) is intentionally unchanged — removing your own binding grants no access.

## Notes
- This is the load-bearing per-sensor gate for the live-streaming path; the broker can't enforce it because the bind is server-side.
- Behavior change: callers who were subscribing to sensors they lack read on will now be denied (that's the point). Legitimate, permissioned callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)