### PR TITLE
Make app queues durable so they survive broker restarts

### DIFF
--- a/buildingdepot/DataService/app/rest_api/apps.py
+++ b/buildingdepot/DataService/app/rest_api/apps.py
@@ -11,12 +11,27 @@ It handles the registration and deletion of apps from the system.
 
 import json
 import traceback
+import hashlib
+import uuid
 from flask import request, jsonify
 from flask.views import MethodView
 
 from . import responses
 from .helper import connect_broker, get_email, check_oauth
 from ..models.ds_models import Application, NodeEncoder
+
+
+def app_queue_name(email):
+    """Durable, owner-scoped name for an app's live-data queue.
+
+    Encodes the owner (a hash of the email, so it is safe in a queue name) so
+    the RabbitMQ /resource auth backend can gate queue access by the connecting
+    user. Explicit + durable so the queue survives broker restarts and can be
+    re-declared idempotently, instead of a transient server-named amq.gen-*
+    queue whose name was persisted in Mongo but vanished on restart.
+    """
+    owner = hashlib.sha256(email.encode("utf-8")).hexdigest()[:16]
+    return "bd.{}.{}".format(owner, uuid.uuid4().hex)
 
 
 class AppService(MethodView):
@@ -109,9 +124,9 @@ class AppService(MethodView):
                     try:
                         channel = pubsub.channel()
                         result = channel.queue_declare(
-                                    durable=False,
-                                    auto_delete=True,
-                                    queue="",
+                                    durable=True,
+                                    auto_delete=False,
+                                    queue=app_queue_name(email),
                                     arguments={
                                         'x-message-ttl': 60000,  # Messages expire after 60 seconds
                                         'x-max-length': 100,      # Keep max 100 messages
@@ -153,9 +168,9 @@ class AppService(MethodView):
                             try:
                                 channel = pubsub.channel()
                                 result = channel.queue_declare(
-                                            durable=False,
-                                            auto_delete=True,
-                                            queue="",
+                                            durable=True,
+                                            auto_delete=False,
+                                            queue=app_queue_name(email),
                                             arguments={
                                                 'x-message-ttl': 60000,
                                                 'x-max-length': 100,


### PR DESCRIPTION
App queues were declared transient (`durable=False, auto_delete=True`) with a server-generated `amq.gen-*` name that we then saved in Mongo forever. The durable record outlived the transient queue: after a broker restart, or once the last consumer disconnected, the queue was gone while the app still pointed at the dead name — so the app quietly stopped receiving data.

Now they're declared durable with an explicit name, `bd.<sha256(email)[:16]>.<uuid4>`:
- survives restarts and consumer churn
- the owner baked into the name lets the RabbitMQ `/resource` auth backend gate read access per user
- same message caps as before (`x-message-ttl` 60s, `x-max-length` 100, drop-head), so durable queues stay small
- `AppService.delete` already deletes the queue, so they don't pile up

Existing apps keep their old `amq.gen-*` names in Mongo; only new apps use the durable naming. Legacy queues are transient and get recreated as durable on the next (re)registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)